### PR TITLE
fix: Install perl dependencies

### DIFF
--- a/setup-os.sh
+++ b/setup-os.sh
@@ -17,6 +17,10 @@ apt-get update
 # Install Node
 apt-get -y install --no-install-recommends nodejs
 
+# Install perl dependencies
+apt-get install -y cpanminus
+cpanm FindBin
+
 # Remove stuff we probably don't need, to save on space
 apt-get -y remove software-properties-common
 apt-get -y autoremove


### PR DESCRIPTION
When building/running this container with imply 2.3.8, I came across an
issue running supervisor where the FindBin module required by
`imply-2.3.8/bin/supervise` was not present. This adds the module.